### PR TITLE
create index and spatial mapping on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ jspm_packages
 
 # Local dev config
 .vscode
+.idea

--- a/config/config.js
+++ b/config/config.js
@@ -22,10 +22,8 @@ c.elasticsearch = {};
 var env = process.env;
 
 // Information about finder
-c.version.major  = 0;
-c.version.minor  = 3;
-c.version.bug    = 0;
-c.version.api    = 1;
+c.version = require('../package.json').version;
+c.api_version = 1;
 
 // network & databases
 c.net.port         = env.FINDER_PORT || 8084;
@@ -37,6 +35,8 @@ c.mongo.collection.jobs = env.FINDER_MONGODB_COLL_JOBS || 'jobs';
 c.mongo.collection.session = env.FINDER_MONGODB_COLL_SESSION || 'sessions';
 
 c.elasticsearch.index = env.FINDER_ELASTICSEARCH_INDEX || 'o2r';
+c.elasticsearch.deleteIndexOnStartup = true;
+c.elasticsearch.putMappingOnStartup = true;
 c.elasticsearch.type = {};
 c.elasticsearch.type.compendia = env.FINDER_ELASTICSEARCH_TYPE_COMPENDIA || 'compendia';
 c.elasticsearch.type.jobs = env.FINDER_ELASTICSEARCH_TYPE_JOBS || 'jobs';

--- a/config/config.js
+++ b/config/config.js
@@ -41,6 +41,8 @@ c.elasticsearch.type = {};
 c.elasticsearch.type.compendia = env.FINDER_ELASTICSEARCH_TYPE_COMPENDIA || 'compendia';
 c.elasticsearch.type.jobs = env.FINDER_ELASTICSEARCH_TYPE_JOBS || 'jobs';
 
+c.elasticsearch.location = env.ELASTIC_SEARCH_URL || 'http://localhost:9200';
+
 // startup
 c.start = {};
 c.start.attempts = env.FINDER_START_PING_ATTEMPS || 6;

--- a/esconfig/mapping.js
+++ b/esconfig/mapping.js
@@ -1,0 +1,49 @@
+/*
+* (C) Copyright 2016 o2r project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+const mapping = {
+    "compendia": {
+        "properties": {
+            "metadata": {
+                "properties": {
+                    "o2r": {
+                        "properties": {
+                            "spatial": {
+                                "properties": {
+                                    "union": {
+                                        "properties": {
+                                            "geojson": {
+                                                "properties": {
+                                                    "geometry": {
+                                                        "type": "geo_shape",
+                                                        "tree": "quadtree"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+module.exports = mapping;

--- a/index.js
+++ b/index.js
@@ -19,8 +19,6 @@ const config = require('./config/config');
 const mapping = require('./esconfig/mapping');
 const debug = require('debug')('finder');
 
-const ElasticSearch = require('elasticsearch');
-
 // MongoDB > Elasticsearch sync
 const ESMongoSync = require('node-elasticsearch-sync');
 
@@ -31,13 +29,13 @@ const esclient = new elasticsearch.Client({
   log: 'info'
 });
 
-var fs = require('fs');
-var dirTree = require('directory-tree');
-var rewriteTree = require('./lib/tree').rewriteTree;
-var readTextfileTree = require('./lib/tree').readTextfileTree;
-var flattenTree = require('./lib/tree').flattenTree;
-var mimeTree = require('./lib/tree').mimeTree;
-var cloneDeep = require('clone-deep');
+const fs = require('fs');
+const dirTree = require('directory-tree');
+const rewriteTree = require('./lib/tree').rewriteTree;
+const readTextfileTree = require('./lib/tree').readTextfileTree;
+const flattenTree = require('./lib/tree').flattenTree;
+const mimeTree = require('./lib/tree').mimeTree;
+const cloneDeep = require('clone-deep');
 
 // database connection for user authentication, ESMongoSync has own connection
 const mongoose = require('mongoose');
@@ -48,14 +46,14 @@ mongoose.connection.on('error', () => {
 });
 
 // rolling queue of the last n transformations
-var CircularBuffer = require("circular-buffer");
-var transformLog = new CircularBuffer(config.sync.logsize);
-debug("Logging last %s transformations in %s", transformLog.capacity(), transformLog);
+const CircularBuffer = require('circular-buffer');
+const transformLog = new CircularBuffer(config.sync.logsize);
+debug('Logging last %s transformations in %s', transformLog.capacity(), transformLog);
 
 // Express modules and tools
-var compression = require('compression');
-var express = require('express');
-var app = express();
+const compression = require('compression');
+const express = require('express');
+const app = express();
 app.use(compression());
 
 app.use((req, res, next) => {
@@ -64,16 +62,16 @@ app.use((req, res, next) => {
 });
 
 // passport & session modules for authenticating users.
-var User = require('./lib/model/user');
-var passport = require('passport');
-var session = require('express-session');
-var MongoDBStore = require('connect-mongodb-session')(session);
+const User = require('./lib/model/user');
+const passport = require('passport');
+const session = require('express-session');
+const MongoDBStore = require('connect-mongodb-session')(session);
 
 passport.serializeUser((user, cb) => {
   cb(null, user.orcid);
 });
 passport.deserializeUser((id, cb) => {
-  debug("Deserialize for %s", id);
+  debug('Deserialize for %s', id);
   User.findOne({ orcid: id }, (err, user) => {
     if (err) cb(err);
     cb(null, user);
@@ -82,7 +80,7 @@ passport.deserializeUser((id, cb) => {
 
 // configure express-session, stores reference to authdetails in cookie.
 // authdetails themselves are stored in MongoDBStore
-var mongoStore = new MongoDBStore({
+const mongoStore = new MongoDBStore({
   uri: config.mongo.location + config.mongo.database,
   collection: config.mongo.collection.session
 });
@@ -110,8 +108,8 @@ app.get('/status', function (req, res) {
     return;
   }
 
-  var response = {
-    name: "finder",
+  let response = {
+    name: 'finder',
     version: config.version,
     levels: config.user.level,
     mongodb: config.mongo,
@@ -127,20 +125,19 @@ app.get('/status', function (req, res) {
     response.elasticsearch = {};
     response.elasticsearch.status = values[1];
     response.elasticsearch.indices = values[0].indices;
-    //console.log(values);
     res.send(response);
   }, error => {
-    debug("Error getting info from Elasticsearch: %s", error.message);
+    debug('Error getting info from Elasticsearch: %s', error.message);
     response.elasticsearch = error;
   }).catch(error => {
-    debug("Error handling promises' results from Elasticsearch: %s", error.message);
+    debug('Error handling promises\' results from Elasticsearch: %s', error.message);
     res.send(response);
   });
 });
 
 // transform functions for node-elasticsearch-sync
-var transformCompendium = function (watcher, compendium, cb) {
-  var id = compendium.id;
+const transformCompendium = function (watcher, compendium, cb) {
+  let id = compendium.id;
   debug('Transforming compendium %s', id);
 
   try {
@@ -151,14 +148,14 @@ var transformCompendium = function (watcher, compendium, cb) {
     delete compendium.__v;
 
     // load file tree
-    var tree = null;
+    let tree = null;
     fs.accessSync(config.fs.compendium + id); // throws if does not exist
     tree = dirTree(config.fs.compendium + id);
 
     // create file tree for metadata
     if (tree) {
       // rewrite copy of tree to API urls, taken from o2r-muncher
-      var apiTree = rewriteTree(cloneDeep(tree),
+      let apiTree = rewriteTree(cloneDeep(tree),
         config.fs.compendium.length + config.id_length, // remove local fs path and id
         '/api/v1/compendium/' + id + '/data' // prepend proper location
       );
@@ -167,9 +164,9 @@ var transformCompendium = function (watcher, compendium, cb) {
 
     // load content of txt files as flat list
     if (tree) {
-      var textTree = mimeTree(cloneDeep(tree));
+      let textTree = mimeTree(cloneDeep(tree));
       readTextfileTree(textTree);
-      var list = [];
+      let list = [];
       flattenTree(textTree,
         config.fs.compendium.length + config.id_length + 1, // make path relative to compendium root
         list);
@@ -182,17 +179,17 @@ var transformCompendium = function (watcher, compendium, cb) {
     //   > http://grokbase.com/t/gg/elasticsearch/148v29ymaf/how-can-we-index-array-of-attachments
     //   > https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html
 
-    transformLog.enq({ time: new Date().toISOString(), compendium: id, transform: "successful" });
-    debug("Transformed compendium %s", id);
+    transformLog.enq({ time: new Date().toISOString(), compendium: id, transform: 'successful' });
+    debug('Transformed compendium %s', id);
     cb(compendium);
   } catch (e) {
-    transformLog.enq({ time: new Date().toISOString(), compendium: id, transform: "error: " + e.message });
-    debug("Error while transforming %s : %s", id, e.message);
+    transformLog.enq({ time: new Date().toISOString(), compendium: id, transform: 'error: ' + e.message });
+    debug('Error while transforming %s : %s', id, e.message);
     cb(null);
   }
 };
 
-var transformJob = function (watcher, job, cb) {
+const transformJob = function (watcher, job, cb) {
   debug('Transforming job %s', job.id);
 
   // shift IDs
@@ -201,13 +198,13 @@ var transformJob = function (watcher, job, cb) {
   delete job._id;
   delete job.__v;
 
-  debug("Transformed job %s", job.id);
+  debug('Transformed job %s', job.id);
   cb(job);
 };
 
 // watchers for node-elasticsearch-sync
-var watchers = [];
-var compendiaWatcher = {
+const watchers = [];
+const compendiaWatcher = {
   collectionName: config.mongo.collection.compendia,
   index: config.elasticsearch.index, // elastic search index
   type: config.elasticsearch.type.compendia, // elastic search type
@@ -215,7 +212,7 @@ var compendiaWatcher = {
   fetchExistingDocuments: config.sync.fetchExisting.compendia, // this will fetch all existing document in collection and index in elastic search
   priority: 1 // defines order of watcher processing. Watchers with low priorities get processed ahead of those with high priorities
 };
-var jobsWatcher = {
+const jobsWatcher = {
   collectionName: config.mongo.collection.jobs,
   index: config.elasticsearch.index,
   type: config.elasticsearch.type.jobs,
@@ -231,7 +228,7 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-var attempts = 1;
+let attempts = 1;
 
 function startSyncWithRetry(watcherArray, maximumNumberOfAttempts, pauseSeconds) {
   if (attempts > maximumNumberOfAttempts) {
@@ -241,7 +238,7 @@ function startSyncWithRetry(watcherArray, maximumNumberOfAttempts, pauseSeconds)
   }
 
   // try to connect to ES before starting sync
-  let EsClient = new ElasticSearch.Client({
+  let EsClient = new elasticsearch.Client({
     host: process.env['ELASTIC_SEARCH_URL'],
     keepAlive: true
   });
@@ -275,29 +272,30 @@ function startSyncWithRetry(watcherArray, maximumNumberOfAttempts, pauseSeconds)
 }
 
 app.listen(config.net.port, () => {
-  //delete existing index and create new index with spatial mapping 
+  // delete existing index and create new index with spatial mapping
+
   esclient.indices.exists({ index: config.elasticsearch.index })
   .then(function (resp) {
-    if (resp) { //if config.elasticsearch.index already exists
-      //delete existing index
+    if (resp) {
+      debug('Index %s already exists: %s', config.elasticsearch.index, resp);
       return esclient.indices.delete({ index: config.elasticsearch.index });
     }
   }).then(function (resp) {
-    //(re)create index
+    debug('Existing index delted: %s', resp);
     return esclient.indices.create({ index: config.elasticsearch.index });
   }).then(function (resp) {
-    //add spatial mapping
-    return esclient.indices.putMapping({ index: config.elasticsearch.index, type: "compendia", body: mapping });
+    debug('Index (re)creation response: %s', resp);
+    return esclient.indices.putMapping({ index: config.elasticsearch.index, type: 'compendia', body: mapping });
   }).then(function (resp) {
-    debug("Created elasticsearch index and mapping");
-    // start listening when the elasticsearch index was created
+    debug('Successfully created elasticsearch index and mapping: %s', resp);
     startSyncWithRetry(watchers, config.start.attempts, config.start.pauseSeconds);
 
-    debug('finder ' + config.version.major + '.' + config.version.minor + '.' +
-      config.version.bug + ' with api version ' + config.version.api +
-      ' waiting for requests on port ' + config.net.port);
+    debug('finder %s with API version %s waiting for requests on port %s',
+        config.version,
+        config.api_version,
+        config.net.port);
   }).catch(function (err) {
-    debug("Error creating index: %s %s", err);
+    debug('Error creating index: %s', err);
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finder",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "all about discovery within o2r",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- create a new index when setting up the finder to enable spatial search
- if the index `config.elasticsearch.index` already exists, it is deleted and recreated
- mapping is loaded from `esconfig/mapping.js`
- requires elasticsearch client version 13 to work, see fix in https://github.com/nuest/node-elasticsearch-sync/pull/1

Together with @jansule 